### PR TITLE
preview画面の追加

### DIFF
--- a/app/controllers/api/v1/dream_diaries_controller.rb
+++ b/app/controllers/api/v1/dream_diaries_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::DreamDiariesController < ApplicationController
   def show
     render json: { status: 200, dream_diary: @dream_diary }
   end
-
+  
   def create
     dream_diary = DreamDiary.new(dream_diary_params)
     if dream_diary.save
@@ -32,8 +32,22 @@ class Api::V1::DreamDiariesController < ApplicationController
     if @dream_diary.destroy
       render json: { status: 200, dream_diary: '削除しました' }
     else
-      render json: { status:500, dream_diary: "削除できません" }
+      render json: { status: 500, dream_diary: "削除できません" }
     end
+  end
+
+  def preview
+    dream_diary = DreamDiary.new(dream_diary_params)
+    if dream_diary.valid?
+      render json: { status: 200, dream_diary: dream_diary }
+    else
+      render json: { status: 401, dream_diary: dream_diary }
+    end
+  end
+
+  def back
+    dream_diary = DreamDiary.new(dream_diary_params)
+    render json: { status: 200, dream_diary: dream_diary }
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
     namespace :v1 do
       root "top#index"
       resources :users, only: %i[destroy]
-      resources :dream_diaries
+      resources :dream_diaries do
+        post 'preview', on: :collection
+        post 'back', on: :collection
+      end
 
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registrations'

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,10 @@ import { BrowserRouter as Router, Route, Routes, Navigate } from "react-router-d
 
 import CommonLayout from "./components/layout/CommonLayout"
 import DreamDiaries from "./components/pages/dreamDiaries/DreamDiaries"
+import DreamDiaryBackForm from "./components/pages/dreamDiaries/DreamDiaryBackForm"
 import DreamDiaryEditForm from "./components/pages/dreamDiaries/DreamDiaryEditForm"
 import DreamDiaryForm from "./components/pages/dreamDiaries/DreamDiaryForm"
+import DreamDiaryPreview from "./components/pages/dreamDiaries/DreamDiaryPreview"
 import DreamDiaryShow from "./components/pages/dreamDiaries/DreamDiaryShow"
 
 import Home from "./components/pages/Home"
@@ -81,6 +83,14 @@ const App: React.FC = () => {
               element={<Private children={<DreamDiaryShow />} />} />
             <Route path="/dreamdiaries/new" 
               element={<Private children={<DreamDiaryForm />} />} />
+            <Route index />
+              <Route path="/dreamdiaries/preview" 
+                element={<Private children={<DreamDiaryPreview />} />} />
+            <Route/>
+            <Route index />
+              <Route path="/dreamdiaries/back"
+                element={<Private children={<DreamDiaryBackForm />} />} />
+            <Route/>
             <Route path="/dreamdiaries/:id/edit" 
               element={<Private children={<DreamDiaryEditForm />} />} />
           </Routes>

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryBackForm.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryBackForm.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useState, useCallback, useContext } from "react"
+import { Box, Button, Card, CardContent, CardHeader, Checkbox, FormControl, FormControlLabel, FormGroup, Grid, IconButton, InputLabel, makeStyles, MenuItem, Select, TextField, Theme } from "@material-ui/core"
+import { KeyboardDatePicker, MuiPickersUtilsProvider } from "@material-ui/pickers"
+import { PhotoCamera } from "@material-ui/icons"
+import AlertMessage from "../../utils/AlertMessage"
+
+import { DreamDiary, DreamDiaryFormData } from "../../../interfaces"
+import { DreamDiaryPreview } from "../../../lib/api/dreamdiaries"
+import { useLocation, useNavigate } from "react-router-dom"
+import { dream_types, impressions } from "../../../data/dreamdiaryEnums"
+import DateFnsUtils from "@date-io/date-fns"
+import CancelIcon from "@material-ui/icons/Cancel"
+import { AuthContext } from "../../../App"
+
+const useStyles = makeStyles((theme: Theme) => ({
+  container: {
+    marginTop: theme.spacing(6)
+  },
+  submitBtn: {
+    marginTop: theme.spacing(1),
+    flexGrow: 1,
+    textTransform: "none"
+  },
+  header: {
+    textAlign: "center"
+  },
+  card: {
+    padding: theme.spacing(2),
+    maxWidth: 800
+  },
+  inputFileButton: {
+    textTransform: "none",
+    color: theme.palette.primary.main
+  },
+  imageUploadBtn: {
+    textAlign: "right"
+  },
+  input: {
+    display: "none"
+  },
+  box: {
+    marginBottom: "1.5rem"
+  },
+  preview: {
+    width: "100%"
+  }
+}))
+
+const DreamDiaryBackForm: React.FC = () => {
+  const classes = useStyles()
+  const navigation = useNavigate()
+  const { currentUser } = useContext(AuthContext)
+
+  const sampleLocation = useLocation();
+  const id = parseInt(sampleLocation.pathname.split('/')[2])
+  const check = sampleLocation.pathname.split('/').pop()
+  
+  const location = useLocation()
+  const [dreamDiaryForm, setDreamDiaryForm] = useState<DreamDiaryFormData>(location.state.dreamDiary)
+  const [title, setTitle] = useState<string>(location.state.dreamDiary.title)
+  const [body, setBody] = useState<string>(location.state.dreamDiary.body)
+  const [prompt, setPrompt] = useState<string>("")
+  const [diaryOgp, setDiaryOgp] = useState<string>("")
+  console.log(title)
+
+  const [state, setState] = useState<boolean>(false)
+  const [impression, setImpression] = useState<number>()
+  const [dreamType, setDreamType] = useState<number>()
+  const [dreamDate, setDreamDate] = useState<Date | null>(new Date("2023-01-01"))
+
+  const [image, setImage] = useState<string>("")
+  const [preview, setPreview] = useState<string>("")
+  const [alertMessageOpen, setAlertMessageOpen] = useState<boolean>(false)
+
+    // アップロードした画像のデータを取得
+    const uploadImage = useCallback((e :any) => {
+      const file = e.target.files[0]
+      setImage(file)
+    }, [])
+  
+    // 画像プレビューを表示
+    const previewImage = useCallback((e :any) => {
+      const file = e.target.files[0]
+      setPreview(window.URL.createObjectURL(file))
+    }, [])
+
+  const createFormData = (): DreamDiaryFormData => {
+    const formData = new FormData()
+
+    formData.append("title", title)
+    formData.append("body", body)
+    formData.append("prompt", prompt)
+    formData.append("diaryOgp", diaryOgp)
+    formData.append("state", String(state))
+    formData.append("impression", String(impression))
+    formData.append("dreamType", String(dreamType))
+    formData.append("dreamDate", String(dreamDate))
+    formData.append("userId", String(currentUser?.id))
+
+    return formData
+  }
+
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    const data = createFormData()
+    
+    try {
+      console.log(data)
+      const res = await DreamDiaryPreview(data)
+      console.log(res)
+
+      if (res.status === 200) {
+        navigation('/dreamdiaries/preview',
+         { state: {dreamDiary: res.data.dreamDiary} })
+
+      } else {
+        setAlertMessageOpen(true)
+      }
+    } catch (err) {
+      console.log(err)
+      setAlertMessageOpen(true)
+    }
+  }
+
+  return (
+        <>
+      <form noValidate autoComplete="off">
+        <Card className={classes.card}>
+          <CardHeader className={classes.header} title="夢絵日記 編集" />
+          <CardContent>
+            <TextField
+              variant="outlined"
+              required
+              fullWidth
+              label="タイトル"
+              value={title}
+              margin="dense"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+            />
+            <TextField
+              variant="outlined"
+              required
+              fullWidth
+              multiline
+              rows={4}
+              label="夢の内容"
+              value={body}
+              margin="dense"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBody(e.target.value)}
+            />
+            <TextField
+              variant="outlined"
+              required
+              fullWidth
+              label="呪文"
+              type="prompt"
+              value={prompt}
+              margin="dense"
+              autoComplete="current-password"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPrompt(e.target.value)}
+            />
+            <FormControl
+              variant="outlined"
+              margin="dense"
+              fullWidth
+            >
+              <InputLabel id="demo-simple-select-outlined-label">夢の印象</InputLabel>
+              <Select
+                labelId="demo-simple-select-outlined-label"
+                id="demo-simple-select-outlined"
+                value={impression}
+                onChange={(e: React.ChangeEvent<{ value: unknown }>) => setImpression(e.target.value as number)}
+                label="夢の印象"
+              >
+                {
+                  impressions.map((impression: string, index: number) => 
+                    <MenuItem value={index}>{impression}</MenuItem>
+                  )
+                }
+              </Select>
+            </FormControl>
+            <FormControl
+              variant="outlined"
+              margin="dense"
+              fullWidth
+            >
+              <InputLabel id="demo-simple-select-outlined-label">睡眠の種類</InputLabel>
+              <Select
+                labelId="demo-simple-select-outlined-label"
+                id="demo-simple-select-outlined"
+                value={dreamType}
+                onChange={(e: React.ChangeEvent<{ value: unknown }>) => setDreamType(e.target.value as number)}
+                label="睡眠の種類"
+              >
+                {
+                  dream_types.map((dreamType: string, index: number) => 
+                    <MenuItem value={index}>{dreamType}</MenuItem>
+                  )
+                }
+              </Select>
+            </FormControl>
+              <FormGroup>
+                <FormControlLabel
+                  defaultChecked
+                  control={<Checkbox /> } 
+                  value={Boolean(state)} 
+                  onChange={(state: any) => setState(state => !state)} 
+                  label={ Boolean(state) === true ? "公開切替え：公開中" : "公開切替え：非公開中" } />
+              </FormGroup>
+            <MuiPickersUtilsProvider utils={DateFnsUtils}>
+              <Grid container justify="space-around">
+                <KeyboardDatePicker
+                  fullWidth
+                  inputVariant="outlined"
+                  margin="dense"
+                  id="date-picker-dialog"
+                  label="夢を見た日"
+                  format="MM/dd/yyyy"
+                  value={dreamDate}
+                  onChange={(date: Date | null) => {
+                    setDreamDate(date)
+                  }}
+                  KeyboardButtonProps={{
+                    "aria-label": "change date",
+                  }}
+                />
+              </Grid>
+            </MuiPickersUtilsProvider>
+            <div className={classes.imageUploadBtn}>
+              <input
+                accept="image/*"
+                className={classes.input}
+                id="icon-button-file"
+                type="file"
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  uploadImage(e)
+                  previewImage(e)
+                }}
+              />
+              <label htmlFor="icon-button-file">
+                <IconButton
+                  color="primary"
+                  aria-label="upload picture"
+                  component="span"
+                >
+                  <PhotoCamera />
+                </IconButton>
+              </label>
+            </div>
+            {
+              preview ? (
+                <Box
+                  className={classes.box}
+                >
+                  <IconButton
+                    color="inherit"
+                    onClick={() => setPreview("")}
+                  >
+                    <CancelIcon />
+                  </IconButton>
+                  <img
+                    src={preview}
+                    alt="preview img"
+                    className={classes.preview}
+                  />
+                </Box>
+              ) : null
+            }
+            <div style={{ textAlign: "right"}} >
+              <Button
+                type="submit"
+                variant="outlined"
+                color="primary"
+                disabled={!title || !body ? true : false} // 空欄があった場合はボタンを押せないように
+                className={classes.submitBtn}
+                onClick={handleSubmit}
+              >
+                送信
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </form>
+      <AlertMessage // エラーが発生した場合はアラートを表示
+        open={alertMessageOpen}
+        setOpen={setAlertMessageOpen}
+        severity="error"
+        message="記入内容を確かめてください。"
+      />
+    </>
+  )
+}
+
+export default DreamDiaryBackForm

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryEditForm.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryEditForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useContext, memo } from "react"
+import React, { useEffect, useState, useCallback, useContext } from "react"
 import { Box, Button, Card, CardContent, CardHeader, Checkbox, FormControl, FormControlLabel, FormGroup, Grid, IconButton, InputLabel, makeStyles, MenuItem, Select, TextField, Theme } from "@material-ui/core"
 import { KeyboardDatePicker, MuiPickersUtilsProvider } from "@material-ui/pickers"
 import { PhotoCamera } from "@material-ui/icons"
@@ -11,7 +11,6 @@ import { dream_types, impressions } from "../../../data/dreamdiaryEnums"
 import DateFnsUtils from "@date-io/date-fns"
 import CancelIcon from "@material-ui/icons/Cancel"
 import { AuthContext } from "../../../App"
-import { useForm } from "react-hook-form"
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -54,20 +53,18 @@ const DreamDiaryEditForm: React.FC = () => {
 
   const sampleLocation = useLocation();
   const id = parseInt(sampleLocation.pathname.split('/')[2])
-
   const [loading, setLoading] = useState<boolean>(true)
-  const [dreamDiary, setDreamDiary] = useState<DreamDiary>()
   
   const [title, setTitle] = useState<string>("")
   const [body, setBody] = useState<string>("")
   const [prompt, setPrompt] = useState<string>("")
   const [diaryOgp, setDiaryOgp] = useState<string>("")
 
-  const [state, setState] = useState<number>(0)
+  const [state, setState] = useState<boolean>(false)
   const [impression, setImpression] = useState<number>()
   const [dreamType, setDreamType] = useState<number>()
   const [dreamDate, setDreamDate] = useState<Date | null>(new Date("2023-01-01"))
-console.log('aaaa')
+
   const [image, setImage] = useState<string>("")
   const [preview, setPreview] = useState<string>("")
   const [alertMessageOpen, setAlertMessageOpen] = useState<boolean>(false)
@@ -78,10 +75,14 @@ console.log('aaaa')
       console.log(res)
 
       if (res.status === 200) {
-        setDreamDiary(res.data.dreamDiary)
-
-        // APIデータを編集フォームに持ってくるやり方が分からん
-        // setTitle(String(dreamDiary?.title))
+        // setDreamDiary(res.data.dreamDiary)
+        setTitle(String(res.data.dreamDiary?.title))
+        setBody(String(res.data.dreamDiary?.body))
+        setPrompt(String(res.data.dreamDiary?.prompt))
+        setImpression(res.data.dreamDiary.impression)
+        setDreamType(res.data.dreamDiary.dreamType)
+        setState(Boolean(res.data.dreamDiary.state))
+        setDreamDate(res.data.dreamDiary.dreamDate)
 
       } else {
         console.log("No diary")
@@ -136,15 +137,6 @@ console.log('aaaa')
 
       if (res.status === 200) {
         navigation(`/dreamdiaries/${id}`)
-
-        setTitle("")
-        setBody("")
-        setPrompt("")
-        setDiaryOgp("")
-        setState(0)
-        setImpression(undefined)
-        setDreamType(undefined)
-        setDreamDate(null)
 
         console.log("Diary updated!")
       } else {
@@ -241,7 +233,8 @@ console.log('aaaa')
                   defaultChecked
                   control={<Checkbox /> } 
                   value={state} 
-                  onChange={(state: any) => setState(state as number)} label="公開" />
+                  onChange={(state: any) => setState(state => !state)} 
+                  label={ Boolean(state) === true ? "公開中(チェックで切替え)" : "非公開中(チェックで切替え)" } />
               </FormGroup>
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <Grid container justify="space-around">

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryEditForm.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryEditForm.tsx
@@ -4,7 +4,7 @@ import { KeyboardDatePicker, MuiPickersUtilsProvider } from "@material-ui/picker
 import { PhotoCamera } from "@material-ui/icons"
 import AlertMessage from "../../utils/AlertMessage"
 
-import { DreamDiary, DreamDiaryFormData } from "../../../interfaces"
+import { DreamDiaryFormData } from "../../../interfaces"
 import { DreamDiaryUpdate, getDreamDiary } from "../../../lib/api/dreamdiaries"
 import { useLocation, useNavigate } from "react-router-dom"
 import { dream_types, impressions } from "../../../data/dreamdiaryEnums"
@@ -53,6 +53,8 @@ const DreamDiaryEditForm: React.FC = () => {
 
   const sampleLocation = useLocation();
   const id = parseInt(sampleLocation.pathname.split('/')[2])
+  const check = sampleLocation.pathname.split('/').pop()
+
   const [loading, setLoading] = useState<boolean>(true)
   
   const [title, setTitle] = useState<string>("")
@@ -232,9 +234,9 @@ const DreamDiaryEditForm: React.FC = () => {
                 <FormControlLabel
                   defaultChecked
                   control={<Checkbox /> } 
-                  value={state} 
+                  value={Boolean(state)} 
                   onChange={(state: any) => setState(state => !state)} 
-                  label={ Boolean(state) === true ? "公開中(チェックで切替え)" : "非公開中(チェックで切替え)" } />
+                  label={ Boolean(state) === true ? "公開切替え：公開中" : "公開切替え：非公開中" } />
               </FormGroup>
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <Grid container justify="space-around">

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryForm.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryForm.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState, useCallback, useContext } from "react"
+import React, { useState, useCallback, useContext } from "react"
 import { Box, Button, Card, CardContent, CardHeader, Checkbox, FormControl, FormControlLabel, FormGroup, Grid, IconButton, InputLabel, makeStyles, MenuItem, Select, TextField, Theme } from "@material-ui/core"
 import { KeyboardDatePicker, MuiPickersUtilsProvider } from "@material-ui/pickers"
 import { PhotoCamera } from "@material-ui/icons"
 import AlertMessage from "../../utils/AlertMessage"
 
 import { DreamDiaryFormData } from "../../../interfaces"
-import { DreamDiaryCreate } from "../../../lib/api/dreamdiaries"
+import { DreamDiaryPreview } from "../../../lib/api/dreamdiaries"
 import { useNavigate } from "react-router-dom"
 import { dream_types, impressions } from "../../../data/dreamdiaryEnums"
 import DateFnsUtils from "@date-io/date-fns"
@@ -95,27 +95,17 @@ const DreamDiaryForm: React.FC = () => {
 
   const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
-
     const data = createFormData()
     
     try {
       console.log(data)
-      const res = await DreamDiaryCreate(data)
+      const res = await DreamDiaryPreview(data)
       console.log(res)
 
       if (res.status === 200) {
-        navigation(`/dreamdiaries/${res.data.id}`)
+        navigation('/dreamdiaries/preview',
+         { state: {dreamDiary: res.data.dreamDiary} })
 
-        setTitle("")
-        setBody("")
-        setPrompt("")
-        setDiaryOgp("")
-        setState(0)
-        setImpression(undefined)
-        setDreamType(undefined)
-        setDreamDate(null)
-
-        console.log("Diary created!")
       } else {
         setAlertMessageOpen(true)
       }
@@ -207,7 +197,7 @@ const DreamDiaryForm: React.FC = () => {
                   defaultChecked
                   control={<Checkbox /> } 
                   value={state} 
-                  onChange={(state: any) => setState(state as number)} label="公開" />
+                  onChange={(state: any) => setState(state as number)} label="公開する" />
             </FormGroup>
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <Grid container justify="space-around">

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryPreview.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryPreview.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react"
+import { Button, makeStyles, Theme } from "@material-ui/core"
+import { Link, useLocation, useNavigate } from "react-router-dom"
+import { AuthContext } from "../../../App"
+
+import { DreamDiary, DreamDiaryFormData } from "../../../interfaces"
+import { DreamDiaryBack, DreamDiaryCreate } from "../../../lib/api/dreamdiaries"
+
+
+const DreamDiaryPreview: React.FC = () => {
+  const location = useLocation()
+  const [dreamDiaryForm, setDreamDiaryForm] = useState<DreamDiaryFormData>(location.state.dreamDiary)
+  const [title, setTitle] = useState<string>(location.state.dreamDiary.title)
+  const [body, setBody] = useState<string>(location.state.dreamDiary.body)
+
+  const navigation = useNavigate();
+
+  const handleSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    
+    try {
+      const res = await DreamDiaryCreate(dreamDiaryForm)
+      console.log(res)
+
+      if (res.status === 200) {
+        navigation(`/dreamdiaries/${res.data.id}`)
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  const handleBack = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    
+    try {
+      const res = await DreamDiaryBack(dreamDiaryForm)
+      console.log(res)
+
+      if (res.status === 200) {
+        navigation('/dreamdiaries/back', { state: { dreamDiary: dreamDiaryForm }})
+      }
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return (
+    <>
+      <div>プレビュー</div>
+      <div>{`title: ${title}`}</div>
+      <div>{`body: ${body}`}</div>
+      {/* <div>{`prompt: ${dreamDiary?.prompt}`}</div>
+      <div>{`state: ${dreamDiary?.state}`}</div>
+      <div>{`impression: ${dreamDiary?.impression}`}</div>
+      <div>{`dreamType: ${dreamDiary?.dreamType}`}</div>
+      <div>{`dreamDate: ${dreamDiary?.dreamDate}`}</div> */}
+      <Button
+        type="submit"
+        variant="outlined"
+        color="primary"
+        onClick={handleBack}
+      >
+      戻る
+      </Button>
+      <Button
+        type="submit"
+        variant="outlined"
+        color="primary"
+        onClick={handleSubmit}
+      >
+      送信
+      </Button>
+    </>
+  )
+}
+
+export default DreamDiaryPreview

--- a/frontend/src/components/pages/dreamDiaries/DreamDiaryShow.tsx
+++ b/frontend/src/components/pages/dreamDiaries/DreamDiaryShow.tsx
@@ -1,6 +1,6 @@
 import { Button, makeStyles, Theme } from "@material-ui/core"
 import React, { useContext, useEffect, useState } from "react"
-import { Link, useLocation, useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import { AuthContext } from "../../../App"
 
 import { DreamDiary } from "../../../interfaces"
@@ -72,6 +72,7 @@ const DreamDiaryShow: React.FC = () => {
           <div>{`title: ${dreamDiary?.title}`}</div>
           <div>{`body: ${dreamDiary?.body}`}</div>
           <div>{`state: ${dreamDiary?.state}`}</div>
+          <div>{`dreamDate: ${dreamDiary?.dreamDate}`}</div>
           <Button
             color="inherit"
             className={classes.linkBtn}

--- a/frontend/src/lib/api/dreamdiaries.ts
+++ b/frontend/src/lib/api/dreamdiaries.ts
@@ -22,9 +22,19 @@ export const getDreamDiary = (id: number) => {
   })
 }
 
-//createへのpostリクエスト、newから
+//previewへのpostリクエスト、newから
+export const DreamDiaryPreview = (data: DreamDiaryFormData) => {
+  return client.post("dream_diaries/preview", data )
+}
+
+//createへのpostリクエスト、previewから
 export const DreamDiaryCreate = (data: DreamDiaryFormData) => {
   return client.post("dream_diaries", data )
+}
+
+//backへのpostリクエスト、previewから
+export const DreamDiaryBack = (data: DreamDiaryFormData) => {
+  return client.post("dream_diaries/back", data )
 }
 
 // updateへのputリクエスト、editから


### PR DESCRIPTION
新規作成フォーム→プレビュー→情報登録
新規作成フォーム→プレビュー→新規作成フォーム→プレビュー→情報登録
を、可能にした。

#17 の課題解消
・edit画面にてDB情報を初期値として設定完了

今後の課題
・画像生成を機能として追加
・編集フォームからプレビュー遷移させるようにする
・コードが汚すぎるのでコンポーネントを切り分けて整理する